### PR TITLE
Rotating the file if exif data has rotation metadata

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -139,6 +139,8 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
         newImage = [ImagePickerUtils resizeImage:image
                                      maxWidth:[self.options[@"maxWidth"] floatValue]
                                     maxHeight:[self.options[@"maxHeight"] floatValue]];
+
+        newImage = [ImagePickerUtils rotateImageIfRequired:newImage];
     }
 
     float quality = [self.options[@"quality"] floatValue];

--- a/ios/ImagePickerUtils.h
+++ b/ios/ImagePickerUtils.h
@@ -15,6 +15,8 @@
 
 + (UIImage*)resizeImage:(UIImage*)image maxWidth:(float)maxWidth maxHeight:(float)maxHeight;
 
++ (UIImage*)rotateImageIfRequired:(UIImage*)image;
+
 + (CGSize)getVideoDimensionsFromUrl:(NSURL *)url;
 
 + (NSString *) getFileTypeFromUrl:(NSURL *)url;

--- a/ios/ImagePickerUtils.m
+++ b/ios/ImagePickerUtils.m
@@ -4,6 +4,8 @@
 
 @implementation ImagePickerUtils
 
+static inline double degreesToRadians (double degrees) {return degrees * M_PI/180;}
+
 + (void) setupPickerFromOptions:(UIImagePickerController *)picker options:(NSDictionary *)options target:(RNImagePickerTarget)target
 {
     if ([[options objectForKey:@"mediaType"] isEqualToString:@"video"]) {
@@ -165,6 +167,27 @@
     UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
     if (newImage == nil) {
         NSLog(@"could not scale image");
+    }
+    UIGraphicsEndImageContext();
+
+    return newImage;
+}
+
++ (UIImage*)rotateImageIfRequired:(UIImage*)image
+{
+    UIGraphicsBeginImageContext(image.size);
+    [image drawInRect:CGRectMake(0, 0, image.size.width, image.size.height)];
+    UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    if (image.imageOrientation == UIImageOrientationRight) {
+      CGContextRotateCTM (context, degreesToRadians(90));
+    } else if (image.imageOrientation == UIImageOrientationLeft) {
+      CGContextRotateCTM (context, degreesToRadians(-90));
+    } else if (image.imageOrientation == UIImageOrientationDown) {
+      CGContextRotateCTM (context, degreesToRadians(180));
+    } else if (image.imageOrientation == UIImageOrientationUp) {
+      CGContextRotateCTM (context, degreesToRadians(90));
     }
     UIGraphicsEndImageContext();
 


### PR DESCRIPTION
| References    |
| ------------- |
| [Task](https://www.tarobi-dev-test.com/guilded-dev/groups/G3pnnL0d/channels/3b04473f-6fb3-42fb-9ba2-f78146a023cd/list?listItemId=2fdc7d41-4d1f-4662-ae5a-640003a0e929)   |

## Motivation (required)

Some images having exif rotation data are displaying upside down or sideways. Lot of other people have complained about this but there is no fix in the the original library.

Before making changes:

https://github.com/TeamGuilded/react-native-image-picker/assets/10223307/a9a90390-933d-40d9-8990-6742eb7d60fc

After making these changes:

https://github.com/TeamGuilded/react-native-image-picker/assets/10223307/187ddbcb-99c8-4200-a298-468d839a8350



## Test Plan (required)

Will be testing on multiple devices/ios versions using simulator as well as actual devices including asking team to test it for various ios versions/devices
